### PR TITLE
ci: stop dist plan failing on Dependabot checkout SHA drift

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,11 @@ members = [ "cargo:." ]
 cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
+# Allow release.yml to drift from `dist generate-ci` output. Dependabot bumps
+# action SHAs (e.g. actions/checkout) directly in release.yml; without this,
+# `dist plan` fails its CI-consistency check and blocks releases. See the
+# github-action-commits pins below, which are kept in sync with the repo.
+allow-dirty = [ "ci" ]
 # The installers to generate for each app
 installers = [ "shell", "powershell", "homebrew" ]
 # Target platforms to build apps for (Rust target-triple syntax)
@@ -55,7 +60,7 @@ install-success-msg = "Successfully installed Stringy! Ready to start looking at
 [dist.github]
 repository = "EvilBit-Labs/Stringy"
 [dist.github-action-commits]
-"actions/checkout"          = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+"actions/checkout"          = "df4cb1c069e1874edd31b4311f1884172cec0e10"
 "actions/download-artifact" = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 "actions/upload-artifact"   = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 "actions/attest"            = "59d89421af93a897026c735860bf21b6eb4f7b26"


### PR DESCRIPTION
## Problem

The cargo-dist `plan` job is failing (Security/Release workflows, since ~2026-06-20). Root cause:

- `dist-workspace.toml` pins `[dist.github-action-commits]."actions/checkout" = "9c091bb…"` (v5.0.0)
- Committed `release.yml` pins `df4cb1c…` (v4.2.2) in all 6 jobs -- the repo's standard, kept current by Dependabot's `github-actions` ecosystem
- Dependabot edits the cargo-dist-**generated** `release.yml` but never touches `dist-workspace.toml`, so `dist plan` regenerates from config, sees the committed file as "out of date," and exits 255

### Impact

- Does **not** block PR merges -- `Release` is not in `.mergify.yml` merge conditions (that's why recent PRs merged fine).
- **Will block the next tagged release**: cargo-dist gates its entire release pipeline on `plan` succeeding, so a `vX.Y.Z` tag would fail at the `plan` step.

## Fix

`dist-workspace.toml` only (6 lines, no `release.yml` churn):

1. `allow-dirty = [ "ci" ]` -- `dist plan` no longer enforces release.yml CI-consistency, so Dependabot can bump action SHAs without breaking releases. This is the recurrence guard.
2. Sync the `actions/checkout` pin `9c091bb` -> `df4cb1c` to match the repo standard, so config agrees with reality and stays consistent if `allow-dirty` is ever removed.

## Verification

- `dist plan` exits **0** (was 255).
- Full `just ci-check` passes.
- No change to `release.yml` (confirmed via `git diff`).

## Notes

This is a deliberately minimal stopgap. The longer-term plan is to migrate off cargo-dist (now unmaintained) to goreleaser or similar; this change avoids investing in dist machinery while keeping releases unblocked until then.

## Test plan

- [x] `dist plan` exits 0 locally
- [x] `just ci-check` green
- [ ] CI green on this PR