### PR TITLE
chore: add issue/PR templates and setup.sh bootstrap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug Report
+description: Report a problem with Stringy
+title: "bug: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        Before you start, please:
+
+        - Search [existing issues](https://github.com/EvilBit-Labs/Stringy/issues) to avoid duplicates.
+        - Do **not** report security vulnerabilities here. Use
+          [private vulnerability reporting](https://github.com/EvilBit-Labs/Stringy/security/advisories/new)
+          instead (see [SECURITY.md](https://github.com/EvilBit-Labs/Stringy/blob/main/SECURITY.md)).
+  - type: input
+    id: version
+    attributes:
+      label: Stringy version
+      description: Output of `stringy --version` (or the commit SHA if built from source).
+      placeholder: "stringy 0.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Where are you running Stringy?
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: format
+    attributes:
+      label: Binary format involved
+      description: The format of the input binary, if relevant.
+      options:
+        - ELF
+        - PE
+        - Mach-O
+        - Not format-specific / unknown
+    validations:
+      required: false
+  - type: input
+    id: command
+    attributes:
+      label: Command run
+      description: The exact command line that triggered the problem.
+      placeholder: "stringy --only-tags url ./target_binary"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include the full error message if any.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Minimal steps to reproduce. If the input binary can be shared, attach it or
+        describe how to obtain an equivalent. Public sample binaries are ideal.
+      placeholder: |
+        1. Build/obtain binary X
+        2. Run `stringy ...`
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: debug
+    attributes:
+      label: Debug output
+      description: >
+        Optional. Output of `stringy --debug <file>` can help diagnose extraction and
+        classification issues. This will be rendered as a code block, so no backticks needed.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Keep blank issues enabled so general questions still have a home
+# (CONTRIBUTING.md directs "unsure where to start" questions to a plain issue).
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/EvilBit-Labs/Stringy/security/advisories/new
+    about: >
+      Do not open a public issue for security problems. Use private vulnerability
+      reporting. See SECURITY.md for scope, safe harbor, and our PGP key.
+  - name: Contributing guide
+    url: https://github.com/EvilBit-Labs/Stringy/blob/main/CONTRIBUTING.md
+    about: Development setup, coding standards, and the pull request process.
+  - name: Known gotchas
+    url: https://github.com/EvilBit-Labs/Stringy/blob/main/GOTCHAS.md
+    about: Hard-won lessons and edge cases before you dig into the code.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: Suggest a new capability or improvement for Stringy
+title: "feat: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+
+        Before you start, please:
+
+        - Search [existing issues](https://github.com/EvilBit-Labs/Stringy/issues) and the
+          [roadmap](https://github.com/EvilBit-Labs/Stringy/blob/main/ROADMAP.md) to avoid duplicates.
+        - For larger changes, open this issue to discuss scope **before** sending a pull request
+          (see [CONTRIBUTING.md](https://github.com/EvilBit-Labs/Stringy/blob/main/CONTRIBUTING.md)).
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What are you trying to do, and what is getting in the way today?
+      placeholder: "When analyzing PE resources, I cannot ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        Describe the feature. For a new semantic tag, new section weight, new encoding, or
+        new output format, note which module it would touch (container, extraction,
+        classification, output, pipeline).
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why they fall short.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Stringy does this most affect?
+      options:
+        - Container parsing (ELF / PE / Mach-O)
+        - String extraction / encoding / dedup
+        - Semantic classification / ranking
+        - Output formatting (table / JSON / YARA)
+        - Pipeline / CLI
+        - Documentation
+        - Other
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for contributing to Stringy. Keep PRs focused and small when possible.
+See CONTRIBUTING.md for coding standards and the review process.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Related issues
+
+<!-- Link issues this closes or relates to, e.g. "Closes #123". Large changes should
+     have a discussion issue opened first. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation only
+- [ ] Refactor / internal change (no user-facing behavior change)
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`) per the DCO
+- [ ] `cargo fmt` produces no changes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] Tests added or updated for behavior changes (`just test`)
+- [ ] No `unsafe` code, and no new `unwrap()`/`panic!` in library code
+- [ ] ASCII-only in code and docs (no emoji, em-dashes, or smart quotes)
+- [ ] Docs updated when behavior changed (README/docs), and AGENTS.md updated if architecture changed
+- [ ] `just ci-check` passes locally (or the relevant subset)
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, trade-offs, or follow-ups deferred to later PRs. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Thanks for your interest in Stringy. This guide explains how to propose changes 
 
 Stringy uses Rust 2024 (MSRV 1.91+, see `rust-toolchain.toml`). We also use just for common tasks.
 
+The fastest way to get a working environment from a fresh clone is `./setup.sh`, which installs the pinned toolchain via [mise](https://mise.jdx.dev) and builds the test fixtures. It requires mise to be installed first and prints instructions if it is missing.
+
 Recommended workflow:
 
 - `just setup` (to install tools)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ cargo build --release
 ./target/release/stringy --help
 ```
 
+For a full development environment (pinned toolchain plus test fixtures), run `./setup.sh`, which bootstraps everything via [mise](https://mise.jdx.dev). See [CONTRIBUTING.md] for details.
+
 ### Basic Usage
 
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# setup.sh - one-command bootstrap for a Stringy development environment.
+#
+# Stringy manages its entire toolchain (Rust, Zig, just, and friends) with mise.
+# This script is a thin wrapper around that flow: it verifies mise is present,
+# installs the pinned tools, and builds the test fixtures so `just test` works.
+#
+# It intentionally does NOT pipe a remote installer into your shell. If mise is
+# missing, it prints the official install instructions and exits.
+#
+# Usage:
+#   ./setup.sh
+#
+# For day-to-day tasks after setup, use the just recipes (see `just --list`).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if ! command -v mise >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+error: mise is not installed.
+
+Stringy uses mise (https://mise.jdx.dev) to manage its toolchain. Install it,
+then re-run ./setup.sh. See https://mise.jdx.dev/getting-started.html
+
+  macOS/Linux (Homebrew):  brew install mise
+  macOS/Linux (script):    https://mise.jdx.dev/getting-started.html
+  Windows:                 https://mise.jdx.dev/getting-started.html#windows
+
+After installing, make sure mise is activated in your shell, or run the commands
+below through `mise exec --`.
+EOF
+  exit 1
+fi
+
+echo "==> Installing pinned toolchain via mise"
+mise trust
+mise install
+
+echo "==> Generating test fixtures (cross-compiled via Zig)"
+mise exec -- just gen-fixtures
+
+cat <<'EOF'
+
+Setup complete. Next steps:
+
+  just build      # debug build
+  just test       # run the test suite
+  just lint       # run the lint suite
+  just ci-check   # full local CI parity check
+
+Run `just --list` to see all available recipes.
+EOF


### PR DESCRIPTION
## Summary

Fills open-source packaging gaps that were missing from the repo, without touching or rewriting the existing README/LICENSE/CONTRIBUTING/SECURITY content. All additions match the project's conventions (ASCII-only, DCO, `just`+`mise` toolchain, private security reporting).

## What's added

- **`.github/ISSUE_TEMPLATE/`** - GitHub issue forms (chosen over plain Markdown for better triage data and to fit the repo's structured-config style):
  - `bug_report.yml` - version, platform, binary format, command, expected/actual, repro, optional `--debug` output.
  - `feature_request.yml` - problem/proposal/alternatives plus a module-area dropdown mirroring container/extraction/classification/output/pipeline.
  - `config.yml` - steers vulnerability reports to [private advisories](https://github.com/EvilBit-Labs/Stringy/security/advisories/new) (reinforcing `SECURITY.md`), links CONTRIBUTING and GOTCHAS, and keeps blank issues enabled so the "ask a question" path in CONTRIBUTING still works.
- **`.github/PULL_REQUEST_TEMPLATE.md`** - checklist mirroring the review requirements in `CONTRIBUTING.md` (DCO sign-off, `fmt`, `clippy -D warnings`, tests, no `unsafe`/`unwrap`, ASCII-only, AGENTS.md-on-arch-change, `just ci-check`).
- **`setup.sh`** (executable) - thin idempotent wrapper over `mise trust && mise install && just gen-fixtures` for a one-command dev bootstrap. It deliberately does **not** curl-pipe an installer; if `mise` is missing it prints the official install guidance and exits.

## Polish

- `CONTRIBUTING.md` dev-setup and `README.md` from-source sections now reference `./setup.sh`.

## Validation

- `bash -n` and `shellcheck` pass on `setup.sh`.
- All three issue forms parse as valid YAML.
- ASCII-only sweep clean across all new files.
- Pre-commit hooks pass (mdformat, shellcheck, yaml, large-file/case/merge checks).

## Notes for reviewers

Issue templates use YAML forms rather than the classic `.md` templates. If you'd prefer plain Markdown, easy to swap. No source code changed - docs/config only.